### PR TITLE
I added some templating files for non-article node types that use latex field

### DIFF
--- a/sites/all/modules/problem/problem-node-form.tpl.php
+++ b/sites/all/modules/problem/problem-node-form.tpl.php
@@ -1,0 +1,89 @@
+<div class="node-add-wrapper clear-block">
+    <div class="node-column-main">
+        <?php
+        global $user;
+        //dd($user);
+        ?>
+        <?php if ($form): ?>
+            <?php print drupal_render_children($form); ?>
+        <?php endif; ?>
+    </div>
+   <?php if(db_table_exists('field_user_preamble_value AS preamble')) {
+    $preamble = db_query('SELECT field_user_preamble_value AS preamble
+    FROM field_data_field_user_preamble 
+    WHERE entity_id=' . $user->uid)->fetchObject();
+    $preamble = $preamble->preamble;
+
+    if (empty($preamble)) {
+        $preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';
+    }} else {$preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';}
+    ?>
+
+    <script>
+// There's probably a "cooler" way to do this.
+
+//remove grippies code
+var addNewEvent;
+
+if (document.addEventListener) {
+	addNewEvent= function(element, type, handler) {
+		element.addEventListener(type, handler, false);
+	};
+} else if (document.attachEvent) {
+	addNewEvent= function(element, type, handler) {
+		element.attachEvent("on" + type, handler);
+	};
+} else {
+	addNewEvent= new Function;
+}
+
+addNewEvent(window, 'load', RemoveGrippies);
+
+function RemoveGrippies() {
+
+	var objs = document.getElementsByTagName("div");
+	var oi = 0;
+	var thisObj;
+
+	for (oi = 0; oi != objs.length; oi++) {
+		thisObj = objs[oi];
+		if (thisObj.className == 'grippie') {
+		        thisObj.className = "";
+		}
+	}
+
+	return;
+
+}
+     //end of remove grippies code        
+        
+        jQuery(document).ready(function(){
+	    jQuery('.form-item-field-problem-latex-und-0-metadata').hide();
+
+            jQuery('#edit-field-problem-latex-und-0-preamble').html(<?php
+    echo json_encode($preamble);
+    ?>);                
+        });
+        var preambleShown =0;
+        jQuery('.form-item-field-problem-latex-und-0-preamble label').text('Show preamble »').
+            css('color','#06799F').
+            css('cursor','pointer');
+        jQuery('#edit-field-problem-latex-und-0-preamble').hide();
+	// jQuery('.grippie').remove();
+        jQuery('.form-item-field-problem-latex-und-0-preamble label,.grippie').click(function(){
+            jQuery('#edit-field-problem-latex-und-0-preamble').toggle(500,function(){
+                if (preambleShown==0){
+                    jQuery('.form-item-field-problem-latex-und-0-preamble label').text('« Hide preamble');
+                    preambleShown=1;
+                }else {
+                    jQuery('.form-item-field-problem-latex-und-0-preamble label').text('Show preamble »');
+                    preambleShown=0;
+                }
+                //jQuery('.form-item-field-latex-und-0-preamble label').text('Hide preamble');
+            });
+        });
+    
+    </script>
+
+    <div class="clear"></div>
+</div>

--- a/sites/all/modules/problem/problem.module
+++ b/sites/all/modules/problem/problem.module
@@ -150,7 +150,13 @@ function problem_theme($existing, $type, $theme, $path){
   return array('attach_icon' => array(
 				      'variables' => array('url' => NULL,
 							   'query' => NULL)
-				      ));
+				      ),
+	       'problem_node_form' => array(
+					    'render element' => 'form',            
+					    'template' => 'problem-node-form',
+					    'path' => drupal_get_path('module', 'problem'),
+					    )
+  );
 }
 
 function problem_mode_getSolutions($problem) {

--- a/sites/all/modules/review/review-node-form.tpl.php
+++ b/sites/all/modules/review/review-node-form.tpl.php
@@ -1,0 +1,89 @@
+<div class="node-add-wrapper clear-block">
+    <div class="node-column-main">
+        <?php
+        global $user;
+        //dd($user);
+        ?>
+        <?php if ($form): ?>
+            <?php print drupal_render_children($form); ?>
+        <?php endif; ?>
+    </div>
+   <?php if(db_table_exists('field_user_preamble_value AS preamble')) {
+    $preamble = db_query('SELECT field_user_preamble_value AS preamble
+    FROM field_data_field_user_preamble 
+    WHERE entity_id=' . $user->uid)->fetchObject();
+    $preamble = $preamble->preamble;
+
+    if (empty($preamble)) {
+        $preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';
+    }} else {$preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';}
+    ?>
+
+    <script>
+// There's probably a "cooler" way to do this.
+
+//remove grippies code
+var addNewEvent;
+
+if (document.addEventListener) {
+	addNewEvent= function(element, type, handler) {
+		element.addEventListener(type, handler, false);
+	};
+} else if (document.attachEvent) {
+	addNewEvent= function(element, type, handler) {
+		element.attachEvent("on" + type, handler);
+	};
+} else {
+	addNewEvent= new Function;
+}
+
+addNewEvent(window, 'load', RemoveGrippies);
+
+function RemoveGrippies() {
+
+	var objs = document.getElementsByTagName("div");
+	var oi = 0;
+	var thisObj;
+
+	for (oi = 0; oi != objs.length; oi++) {
+		thisObj = objs[oi];
+		if (thisObj.className == 'grippie') {
+		        thisObj.className = "";
+		}
+	}
+
+	return;
+
+}
+     //end of remove grippies code        
+        
+        jQuery(document).ready(function(){
+	    jQuery('.form-item-field-review-latex-und-0-metadata').hide();
+
+            jQuery('#edit-field-review-latex-und-0-preamble').html(<?php
+    echo json_encode($preamble);
+    ?>);                
+        });
+        var preambleShown =0;
+        jQuery('.form-item-field-review-latex-und-0-preamble label').text('Show preamble »').
+            css('color','#06799F').
+            css('cursor','pointer');
+        jQuery('#edit-field-review-latex-und-0-preamble').hide();
+	// jQuery('.grippie').remove();
+        jQuery('.form-item-field-review-latex-und-0-preamble label,.grippie').click(function(){
+            jQuery('#edit-field-review-latex-und-0-preamble').toggle(500,function(){
+                if (preambleShown==0){
+                    jQuery('.form-item-field-review-latex-und-0-preamble label').text('« Hide preamble');
+                    preambleShown=1;
+                }else {
+                    jQuery('.form-item-field-review-latex-und-0-preamble label').text('Show preamble »');
+                    preambleShown=0;
+                }
+                //jQuery('.form-item-field-latex-und-0-preamble label').text('Hide preamble');
+            });
+        });
+    
+    </script>
+
+    <div class="clear"></div>
+</div>

--- a/sites/all/modules/review/review.install
+++ b/sites/all/modules/review/review.install
@@ -74,7 +74,7 @@ function _review_installed_fields() {
     ),
     'field_review_solution' => array(
       'field_name'  => 'field_review_solution',
-      'label'       => $t('Reference to the solution this review concerns.'),
+      'label'       => $t('Reference to the solution this review concerns'),
       'cardinality' => 1,
       'type'        => 'node_reference',
       'settings'    => array(

--- a/sites/all/modules/solution/solution-node-form.tpl.php
+++ b/sites/all/modules/solution/solution-node-form.tpl.php
@@ -1,0 +1,89 @@
+<div class="node-add-wrapper clear-block">
+    <div class="node-column-main">
+        <?php
+        global $user;
+        //dd($user);
+        ?>
+        <?php if ($form): ?>
+            <?php print drupal_render_children($form); ?>
+        <?php endif; ?>
+    </div>
+   <?php if(db_table_exists('field_user_preamble_value AS preamble')) {
+    $preamble = db_query('SELECT field_user_preamble_value AS preamble
+    FROM field_data_field_user_preamble 
+    WHERE entity_id=' . $user->uid)->fetchObject();
+    $preamble = $preamble->preamble;
+
+    if (empty($preamble)) {
+        $preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';
+    }} else {$preamble = '%SITEWIDE DEFAULT SHOULD GO HERE';}
+    ?>
+
+    <script>
+// There's probably a "cooler" way to do this.
+
+//remove grippies code
+var addNewEvent;
+
+if (document.addEventListener) {
+	addNewEvent= function(element, type, handler) {
+		element.addEventListener(type, handler, false);
+	};
+} else if (document.attachEvent) {
+	addNewEvent= function(element, type, handler) {
+		element.attachEvent("on" + type, handler);
+	};
+} else {
+	addNewEvent= new Function;
+}
+
+addNewEvent(window, 'load', RemoveGrippies);
+
+function RemoveGrippies() {
+
+	var objs = document.getElementsByTagName("div");
+	var oi = 0;
+	var thisObj;
+
+	for (oi = 0; oi != objs.length; oi++) {
+		thisObj = objs[oi];
+		if (thisObj.className == 'grippie') {
+		        thisObj.className = "";
+		}
+	}
+
+	return;
+
+}
+     //end of remove grippies code        
+        
+        jQuery(document).ready(function(){
+	    jQuery('.form-item-field-solution-latex-und-0-metadata').hide();
+
+            jQuery('#edit-field-solution-latex-und-0-preamble').html(<?php
+    echo json_encode($preamble);
+    ?>);                
+        });
+        var preambleShown =0;
+        jQuery('.form-item-field-solution-latex-und-0-preamble label').text('Show preamble »').
+            css('color','#06799F').
+            css('cursor','pointer');
+        jQuery('#edit-field-solution-latex-und-0-preamble').hide();
+	// jQuery('.grippie').remove();
+        jQuery('.form-item-field-solution-latex-und-0-preamble label,.grippie').click(function(){
+            jQuery('#edit-field-solution-latex-und-0-preamble').toggle(500,function(){
+                if (preambleShown==0){
+                    jQuery('.form-item-field-solution-latex-und-0-preamble label').text('« Hide preamble');
+                    preambleShown=1;
+                }else {
+                    jQuery('.form-item-field-solution-latex-und-0-preamble label').text('Show preamble »');
+                    preambleShown=0;
+                }
+                //jQuery('.form-item-field-latex-und-0-preamble label').text('Hide preamble');
+            });
+        });
+    
+    </script>
+
+    <div class="clear"></div>
+</div>

--- a/sites/all/modules/solution/solution.module
+++ b/sites/all/modules/solution/solution.module
@@ -117,6 +117,15 @@ function solution_node_view($node){
   }
 }
 
+function solution_theme($existing, $type, $theme, $path){
+  return array('solution_node_form' => array(
+					    'render element' => 'form',            
+					    'template' => 'solution-node-form',
+					    'path' => drupal_get_path('module', 'solution'),
+					    )
+  );
+}
+
 
 /**
  * Implementation of hook_form_FORM_ID_alter()


### PR DESCRIPTION
This seems "hacky" (since I would rather have the LaTeX field take care of its own theming uniformly) but this works -- to add some hide/show javascript for the preamble, for instance.
